### PR TITLE
Issue 78: Tweaked docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ DXCore version: 10.0.26091.1-240325-1447.ge-release
 Windows version: 10.0.22631.3737
 ```
 
-If the output starts with `WSL version: 2.x.x.x`, you are ready to use **WSL2** and can proceed to [install AlmaLinux10](wsl/README.md).
+If the output starts with `WSL version: 2.x.x.x`, you are ready to use **WSL2** and can proceed to [install AlmaLinux 10](wsl/README.md).
 
 ## Install WSL2
 
@@ -57,4 +57,4 @@ To test, run again the following command:
 wsl -v
 ```
 
-This time the output should display `WSL version: 2.x.x.x`, which means that your system is ready for using **WSL2** and you can proceed to [install AlmaLinux10](wsl/README.md).
+This time the output should display `WSL version: 2.x.x.x`, which means that your system is ready for using **WSL2** and you can proceed to [install AlmaLinux 10](wsl/README.md).

--- a/docs/book/v1/faq.md
+++ b/docs/book/v1/faq.md
@@ -1,4 +1,4 @@
-# Frequently asked questions
+# AlmaLinux 9 Frequently asked questions
 
 ## How do I switch to a different version of PHP?
 

--- a/docs/book/v1/introduction.md
+++ b/docs/book/v1/introduction.md
@@ -1,9 +1,9 @@
-# Introduction
+# AlmaLinux 9 Introduction
 
 `dotkernel/development` is a tool that helps you prepare your development environment with the following components:
 
 * **WSL2**: Windows Subsystem for Linux
-* **AlmaLinux9**: free and open source Linux distribution
+* **AlmaLinux 9**: free and open source Linux distribution
 * **PHP**: general-purpose scripting language geared towards web development
 * **Apache**: free and open-source cross-platform web server software
 * **MariaDB**: community-developed, commercially supported fork of the MySQL relational database management system

--- a/docs/book/v1/setup/installation.md
+++ b/docs/book/v1/setup/installation.md
@@ -25,7 +25,7 @@ If you have other distros installed, the output could look similar to the below:
 
 ```text
   NAME            STATE           VERSION
-* AlmaLinux-9     Stopped         2
+  AlmaLinux-9     Stopped         2
 * AlmaLinux-10    Running         2
 ```
 

--- a/docs/book/v1/setup/installation.md
+++ b/docs/book/v1/setup/installation.md
@@ -1,4 +1,4 @@
-# Install AlmaLinux9
+# AlmaLinux 9 Installation
 
 Before proceeding with the installation, we need to make sure that no other WSL2 distribution (aka: _distro_) is running.
 This is important because this installation will fail if required ports are already in use by another distro.
@@ -19,7 +19,7 @@ If there is no other distro installed, you will see the below output (an empty l
   NAME            STATE           VERSION
 ```
 
-In this case, you can jump to the [installation](#install-almalinux9-1) section.
+In this case, you can jump to the [installation](#install-almalinux-9) section.
 
 If you have other distros installed, the output could look similar to the below:
 
@@ -30,10 +30,10 @@ If you have other distros installed, the output could look similar to the below:
 ```
 
 Make sure that the **STATE** column reads **Stopped** for all distros.
-If any of them reads **Running**, you must stop if first by executing `wsl -t <distro-name>`, for example: `wsl -t AlmaLinux-10`.
-Once you have stopped all distros, you can continue to the [installation](#install-almalinux9-1) section.
+If any of them reads **Running**, you must stop if first by executing `wsl -t <distro-name>` after replacing `<distro-name>` with the name of the distro you want to stop.
+Once you have stopped all distros, you can continue to the [installation](#install-almalinux-9) section.
 
-## Install AlmaLinux9
+## Install AlmaLinux 9
 
 List the available Linux distros by executing:
 
@@ -82,7 +82,7 @@ A distribution with the supplied name already exists. Use --name to choose a dif
 Error code: Wsl/InstallDistro/Service/RegisterDistro/ERROR_ALREADY_EXISTS
 ```
 
-Install the AlmaLinux9 distro by executing the below command:
+Install the **AlmaLinux 9** distro by executing the below command:
 
 ```shell
 wsl --install -d AlmaLinux-9
@@ -101,7 +101,7 @@ Enter new UNIX username:
 ```
 
 As per the last line, the installation process now prompts you to enter a username.
-This is the username you will use inside AlmaLinux9, and it can be any alphanumeric string (for example `dotkernel`):
+This is the username you will use inside **AlmaLinux 9**, and it can be any alphanumeric string (for example `dotkernel`):
 
 Next, you are prompted to change the password associated with your chosen username (you will not see what you are typing, that's a security measure in Linux regarding passwords):
 
@@ -123,5 +123,5 @@ Finally, you should see the following message:
 
 ```text
 passwd: all authentication tokens updated successfully.
-[<your-almalinux9-username>@<your-device-name> <your-windows-username>]$
+[<your-alma-linux-9-username>@<your-device-name> <your-windows-username>]$
 ```

--- a/docs/book/v1/setup/setup-packages.md
+++ b/docs/book/v1/setup/setup-packages.md
@@ -1,4 +1,4 @@
-# Setup AlmaLinux9
+# AlmaLinux 9 Setup
 
 Install system packages:
 
@@ -19,7 +19,7 @@ Administrator. It usually boils down to these three things:
 [sudo] password for dotkernel:
 ```
 
-Input your AlmaLinux9 password and hit `Enter`.
+Input your **AlmaLinux 9** password and hit `Enter`.
 
 Update/Upgrade system packages:
 
@@ -33,16 +33,16 @@ Now, install the latest version of **Ansible**:
 sudo dnf install ansible -y
 ```
 
-Move inside your home directory (it is `/home/` followed by your AlmaLinux9 username, for example: `/home/dotkernel`):
+Move inside your home directory (it is `/home/` followed by your **AlmaLinux 9** username, for example: `/home/dotkernel`):
 
 ```shell
 cd ~
 ```
 
-Clone the `almalinux9` branch of the `dotkernel/development` repository:
+Clone the `alma-linux-9` branch of the `dotkernel/development` repository:
 
 ```shell
-git clone --branch almalinux9 --single-branch https://github.com/dotkernel/development.git
+git clone --branch alma-linux-9 --single-branch https://github.com/dotkernel/development.git
 ```
 
 Move inside the directory `development/wsl`:
@@ -66,7 +66,7 @@ Install components by running the below Ansible command:
 ansible-playbook -i hosts install.yml --ask-become-pass
 ```
 
-The installation process will ask for your AlmaLinux9 password, then iterate over each task in the playbook and output a short summary with the results.
+The installation process will ask for your **AlmaLinux 9** password, then iterate over each task in the playbook and output a short summary with the results.
 
 Once finished, check if everything works by opening in your browser:
 
@@ -74,26 +74,26 @@ Once finished, check if everything works by opening in your browser:
 * [http://localhost/info.php](http://localhost/info.php): PHP info page
 * [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/): PhpMyAdmin (login with `root` + the root password you configured in `config.yml` under `mariadb` -> `root_password`)
 
-The installation is complete, your AlmaLinux9 development environment is ready to use.
+The installation is complete, your **AlmaLinux 9** development environment is ready to use.
 
-> Restart your `Windows Terminal` to find a new option in the tab selector, called **AlmaLinux-9** - clicking it will open a new tab connected to **AlmaLinux9**.
+> Restart your `Windows Terminal` to find a new option in the tab selector, called **AlmaLinux-9** - clicking it will open a new tab connected to **AlmaLinux 9**.
 
-## Running AlmaLinux9
+## Running AlmaLinux 9
 
 Open `Windows Terminal`.
 
-Start AlmaLinux9 by executing:
+Start **AlmaLinux 9** by executing:
 
 ```shell
-wsl -d AlmaLinux9
+wsl -d AlmaLinux-9
 ```
 
 OR
 
 Locate the app selector dropdown in `Windows Terminal`'s title bar and click `AlmaLinux-9`.
-This will open a new tab connected to AlmaLinux9.
+This will open a new tab connected to **AlmaLinux 9**.
 
 ### Note
 
-> To run your applications using WSL2, you always need to be connected to your AlmaLinux9 distribution.
+> To run your applications using WSL2, you always need to be connected to your **AlmaLinux 9** distribution.
 > For this, all you need to do is to keep open an instance of Windows Terminal that is connected to it.

--- a/docs/book/v1/setup/system-requirements.md
+++ b/docs/book/v1/setup/system-requirements.md
@@ -1,4 +1,4 @@
-# System requirements
+# AlmaLinux 9 System requirements
 
 If you're not already using it, we recommend you to install [Windows Terminal](https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-US&gl=US).
 It is a modern tool that incorporates the power of multiple already known command-line applications like `Windows PowerShell`, `Linux shell`, and more...
@@ -23,7 +23,7 @@ DXCore version: 10.0.26091.1-240325-1447.ge-release
 Windows version: 10.0.22631.3737
 ```
 
-If the output starts with `WSL version: 2.x.x.x`, you are ready to use **WSL2** and can proceed to [install AlmaLinux9](installation.md).
+If the output starts with `WSL version: 2.x.x.x`, you are ready to use **WSL2** and can proceed to [install AlmaLinux 9](installation.md).
 
 ## Install WSL2
 
@@ -55,4 +55,4 @@ To test, run again the following command:
 wsl -v
 ```
 
-This time the output should display `WSL version: 2.x.x.x`, which means that your system is ready for using **WSL2** and you can proceed to [install AlmaLinux9](installation.md).
+This time the output should display `WSL version: 2.x.x.x`, which means that your system is ready for using **WSL2** and you can proceed to [install AlmaLinux 9](installation.md).

--- a/docs/book/v1/virtualhosts/create-virtualhost.md
+++ b/docs/book/v1/virtualhosts/create-virtualhost.md
@@ -1,4 +1,4 @@
-# Create virtualhosts
+# AlmaLinux 9 Create virtualhosts
 
 > By using the `*.localhost` pattern for any new virtualhost, you do not need to modify the `hosts` file in Windows, because these are routed by default.
 

--- a/docs/book/v1/virtualhosts/create-virtualhost.md
+++ b/docs/book/v1/virtualhosts/create-virtualhost.md
@@ -20,7 +20,7 @@ Create the specified virtualhosts:
 ansible-playbook -i hosts create-virtualhost.yml --ask-become-pass
 ```
 
-This process will ask for your AlmaLinux10 password, iterate over the list of configured `virtualhosts` and output a short summary with the results.
+This process will ask for your **AlmaLinux 9** password, iterate over the list of configured `virtualhosts` and output a short summary with the results.
 Your virtualhost should be accessible and ready to use.
 
 You will install your project under the `html` directory of your project, for example `/var/www/example.localhost/html`.
@@ -31,7 +31,7 @@ You will install your project under the `html` directory of your project, for ex
 
 ## Good to know
 
-* To run your installed projects, you need to start AlmaLinux9 first.
+* To run your installed projects, you need to start **AlmaLinux 9** first.
 * If you work with virtualhosts, your projects are created under `/var/www/`.
 * You can still run PHP scripts under the default Apache project directory, located at `/var/www/html/`.
 * If you encounter write permission issues, see [this guide](https://docs.dotkernel.org/development/v1/faq/#how-do-i-fix-common-permission-issues).

--- a/docs/book/v1/virtualhosts/overview.md
+++ b/docs/book/v1/virtualhosts/overview.md
@@ -11,7 +11,7 @@ Using this tool, you configure a virtualhost for each of your applications, and 
 
 In the above example, the URLs are built like this:
 
-* the subdomain is the identifier of your application (`api`/`frontend`)
+* the subdomain is the identifier of your application (`api` / `frontend`)
 * the domain is the identifier of your project (`dotkernel`)
 * the TLD sends the requests to localhost where Apache will route them to their real location
 

--- a/docs/book/v1/virtualhosts/overview.md
+++ b/docs/book/v1/virtualhosts/overview.md
@@ -1,4 +1,4 @@
-# Overview
+# AlmaLinux 9 Overview
 
 Virtualhosts allow developers to host multiple applications on their local system.
 

--- a/docs/book/v2/faq.md
+++ b/docs/book/v2/faq.md
@@ -27,9 +27,10 @@ php -v
 Depending on the selected PHP version, the output should look similar to the below:
 
 ```text
-PHP 8.3.8 (cli) (built: Jun  4 2024 14:53:17) (NTS gcc x86_64)
+PHP 8.4.8 (cli) (built: Jun  3 2025 16:29:26) (NTS gcc x86_64)
 Copyright (c) The PHP Group
-Zend Engine v4.3.8, Copyright (c) Zend Technologies
+Built by Remi's RPM repository <https://rpms.remirepo.net/> #StandWithUkraine
+Zend Engine v4.4.8, Copyright (c) Zend Technologies
 ```
 
 ## How do I switch to a different version of Node.js?

--- a/docs/book/v2/faq.md
+++ b/docs/book/v2/faq.md
@@ -1,4 +1,4 @@
-# Frequently asked questions
+# AlmaLinux 10 Frequently asked questions
 
 ## How do I switch to a different version of PHP?
 

--- a/docs/book/v2/introduction.md
+++ b/docs/book/v2/introduction.md
@@ -1,9 +1,9 @@
-# Introduction
+# AlmaLinux 10 Introduction
 
 `dotkernel/development` is a tool that helps you prepare your development environment with the following components:
 
 * **WSL2**: Windows Subsystem for Linux
-* **AlmaLinux10**: free and open source Linux distribution
+* **AlmaLinux 10**: free and open source Linux distribution
 * **PHP**: general-purpose scripting language geared towards web development
 * **Apache**: free and open-source cross-platform web server software
 * **MariaDB**: community-developed, commercially supported fork of the MySQL relational database management system

--- a/docs/book/v2/setup/installation.md
+++ b/docs/book/v2/setup/installation.md
@@ -1,4 +1,4 @@
-# Install AlmaLinux10
+# AlmaLinux 10 Installation
 
 Before proceeding with the installation, we need to make sure that no other WSL2 distribution (aka: _distro_) is running.
 This is important because this installation will fail if required ports are already in use by another distro.
@@ -19,21 +19,21 @@ If there is no other distro installed, you will see the below output (an empty l
   NAME            STATE           VERSION
 ```
 
-In this case, you can jump to the [installation](#install-almalinux10-1) section.
+In this case, you can jump to the [installation](#install-almalinux-10) section.
 
 If you have other distros installed, the output could look similar to the below:
 
 ```text
   NAME            STATE           VERSION
-* AlmaLinux-8     Stopped         2
+  AlmaLinux-8     Stopped         2
 * AlmaLinux-9     Running         2
 ```
 
 Make sure that the **STATE** column reads **Stopped** for all distros.
-If any of them reads **Running**, you must stop if first by executing `wsl -t <distro-name>`, for example: `wsl -t AlmaLinux-9`.
-Once you have stopped all distros, you can continue to the [installation](#install-almalinux10-1) section.
+If any of them reads **Running**, you must stop if first by executing `wsl -t <distro-name>` after replacing `<distro-name>` with the name of the distro you want to stop.
+Once you have stopped all distros, you can continue to the [installation](#install-almalinux-10) section.
 
-## Install AlmaLinux10
+## Install AlmaLinux 10
 
 List the available Linux distros by executing:
 
@@ -82,7 +82,7 @@ A distribution with the supplied name already exists. Use --name to choose a dif
 Error code: Wsl/InstallDistro/Service/RegisterDistro/ERROR_ALREADY_EXISTS
 ```
 
-Install the AlmaLinux10 distro by executing the below command:
+Install the **AlmaLinux 10** distro by executing the below command:
 
 ```shell
 wsl --install -d AlmaLinux-10
@@ -101,7 +101,7 @@ Enter new UNIX username:
 ```
 
 As per the last line, the installation process now prompts you to enter a username.
-This is the username you will use inside AlmaLinux10, and it can be any alphanumeric string (for example `dotkernel`):
+This is the username you will use inside **AlmaLinux 10**, and it can be any alphanumeric string (for example `dotkernel`):
 
 Next, you are prompted to change the password associated with your chosen username (you will not see what you are typing, that's a security measure in Linux regarding passwords):
 
@@ -122,5 +122,5 @@ Finally, you should see the following message:
 
 ```text
 passwd: password updated successfully
-[<your-almalinux10-username>@<your-device-name> <your-windows-username>]$
+[<your-alma-linux-10-username>@<your-device-name> <your-windows-username>]$
 ```

--- a/docs/book/v2/setup/setup-packages.md
+++ b/docs/book/v2/setup/setup-packages.md
@@ -1,4 +1,4 @@
-# Setup AlmaLinux10
+# AlmaLinux 10 Setup
 
 Install system packages:
 
@@ -21,7 +21,7 @@ For security reasons, the password you type will not be visible.
 [sudo] password for dotkernel:
 ```
 
-Input your AlmaLinux10 password and hit `Enter`.
+Input your **AlmaLinux 10** password and hit `Enter`.
 
 Update/Upgrade system packages:
 
@@ -39,7 +39,7 @@ sudo dnf install ansible-core -y
 ansible-galaxy collection install community.general community.mysql
 ```
 
-Move inside your home directory (it is `/home/` followed by your AlmaLinux10 username, for example: `/home/dotkernel`):
+Move inside your home directory (it is `/home/` followed by your **AlmaLinux 10** username, for example: `/home/dotkernel`):
 
 ```shell
 cd ~
@@ -72,7 +72,7 @@ Install components by running the below Ansible command:
 ansible-playbook -i hosts install.yml --ask-become-pass
 ```
 
-The installation process will ask for your AlmaLinux10 password, then iterate over each task in the playbook and output a short summary with the results.
+The installation process will ask for your **AlmaLinux 10** password, then iterate over each task in the playbook and output a short summary with the results.
 
 Once finished, check if everything works by opening in your browser:
 
@@ -80,26 +80,26 @@ Once finished, check if everything works by opening in your browser:
 * [http://localhost/info.php](http://localhost/info.php): PHP info page
 * [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/): PhpMyAdmin (login with `root` + the root password you configured in `config.yml` under `mariadb` -> `root_password`)
 
-The installation is complete, your AlmaLinux10 development environment is ready to use.
+The installation is complete, your **AlmaLinux 10** development environment is ready to use.
 
-> Restart your `Windows Terminal` to find a new option in the tab selector, called **AlmaLinux-10**; clicking it will open a new tab connected to **AlmaLinux10**.
+> Restart your `Windows Terminal` to find a new option in the tab selector, called **AlmaLinux-10**; clicking it will open a new tab connected to **AlmaLinux 10**.
 
-## Running AlmaLinux10
+## Running AlmaLinux 10
 
 Open `Windows Terminal`.
 
-Start AlmaLinux10 by executing:
+Start **AlmaLinux 10** by executing:
 
 ```shell
-wsl -d AlmaLinux10
+wsl -d AlmaLinux-10
 ```
 
 OR
 
 Locate the app selector dropdown in `Windows Terminal`'s title bar and click `AlmaLinux-10`.
-This will open a new tab connected to AlmaLinux10.
+This will open a new tab connected to **AlmaLinux 10**.
 
 ### Note
 
-> To run your applications using WSL2, you always need to be connected to your AlmaLinux10 distribution.
+> To run your applications using WSL2, you always need to be connected to your **AlmaLinux 10** distribution.
 > For this, all you need to do is to keep open an instance of Windows Terminal that is connected to it.

--- a/docs/book/v2/setup/system-requirements.md
+++ b/docs/book/v2/setup/system-requirements.md
@@ -1,4 +1,4 @@
-# System requirements
+# AlmaLinux 10 System requirements
 
 If you're not already using it, we recommend you to install [Windows Terminal](https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-US&gl=US).
 It is a modern tool that incorporates the power of multiple already known command-line applications like `Windows PowerShell`, `Linux shell`, and more...
@@ -23,7 +23,7 @@ DXCore version: 10.0.26091.1-240325-1447.ge-release
 Windows version: 10.0.22631.3737
 ```
 
-If the output starts with `WSL version: 2.x.x.x`, you are ready to use **WSL2** and can proceed to [install AlmaLinux10](installation.md).
+If the output starts with `WSL version: 2.x.x.x`, you are ready to use **WSL2** and can proceed to [install AlmaLinux 10](installation.md).
 
 ## Install WSL2
 
@@ -55,4 +55,4 @@ To test, run again the following command:
 wsl -v
 ```
 
-This time the output should display `WSL version: 2.x.x.x`, which means that your system is ready for using **WSL2** and you can proceed to [install AlmaLinux10](installation.md).
+This time the output should display `WSL version: 2.x.x.x`, which means that your system is ready for using **WSL2** and you can proceed to [install AlmaLinux 10](installation.md).

--- a/docs/book/v2/virtualhosts/create-virtualhost.md
+++ b/docs/book/v2/virtualhosts/create-virtualhost.md
@@ -20,7 +20,7 @@ Create the specified virtualhosts:
 ansible-playbook -i hosts create-virtualhost.yml --ask-become-pass
 ```
 
-This process will ask for your AlmaLinux10 password, iterate over the list of configured `virtualhosts` and output a short summary with the results.
+This process will ask for your **AlmaLinux 10** password, iterate over the list of configured `virtualhosts` and output a short summary with the results.
 Your virtualhost should be accessible and ready to use.
 
 You will install your project under the `html` directory of your project, for example `/var/www/example.localhost/html`.
@@ -31,7 +31,7 @@ You will install your project under the `html` directory of your project, for ex
 
 ## Good to know
 
-* To run your installed projects, you need to start AlmaLinux10 first.
+* To run your installed projects, you need to start **AlmaLinux 10** first.
 * If you work with virtualhosts, your projects are created under `/var/www/`.
 * You can still run PHP scripts under the default Apache project directory, located at `/var/www/html/`.
 * If you encounter write permission issues, see [this guide](https://docs.dotkernel.org/development/v2/faq/#how-do-i-fix-common-permission-issues).

--- a/docs/book/v2/virtualhosts/create-virtualhost.md
+++ b/docs/book/v2/virtualhosts/create-virtualhost.md
@@ -1,4 +1,4 @@
-# Create virtualhosts
+# AlmaLinux 10 Create virtualhosts
 
 > By using the `*.localhost` pattern for any new virtualhost, you do not need to modify the `hosts` file in Windows, because these are routed by default.
 

--- a/docs/book/v2/virtualhosts/overview.md
+++ b/docs/book/v2/virtualhosts/overview.md
@@ -11,7 +11,7 @@ Using this tool, you configure a virtualhost for each of your applications, and 
 
 In the above example, the URLs are built like this:
 
-* the subdomain is the identifier of your application (`api`/`frontend`)
+* the subdomain is the identifier of your application (`api` / `frontend`)
 * the domain is the identifier of your project (`dotkernel`)
 * the TLD sends the requests to localhost where Apache will route them to their real location
 

--- a/docs/book/v2/virtualhosts/overview.md
+++ b/docs/book/v2/virtualhosts/overview.md
@@ -1,4 +1,4 @@
-# Overview
+# AlmaLinux 10 Overview
 
 Virtualhosts allow developers to host multiple applications on their local system.
 

--- a/wsl/README.md
+++ b/wsl/README.md
@@ -1,4 +1,4 @@
-# Install AlmaLinux10
+# Install AlmaLinux 10
 
 Before proceeding with the installation, we need to make sure that no other WSL2 distribution (aka: _distro_) is running.
 This is important because this installation will fail if required ports are already in use by another distro.
@@ -19,21 +19,21 @@ If there is no other distro installed, you will see the below output (an empty l
   NAME            STATE           VERSION
 ```
 
-In this case, you can jump to the [installation](#install-almalinux10-1) section.
+In this case, you can jump to the [installation](#install-almalinux-10-1) section.
 
 If you have other distros installed, the output could look similar to the below:
 
 ```text
   NAME            STATE           VERSION
-* AlmaLinux-8     Stopped         2
+  AlmaLinux-8     Stopped         2
 * AlmaLinux-9     Running         2
 ```
 
 Make sure that the **STATE** column reads **Stopped** for all distros.
-If any of them reads **Running**, you must stop if first by executing `wsl -t <distro-name>`, for example: `wsl -t AlmaLinux-9`.
-Once you have stopped all distros, you can continue to the [installation](#install-almalinux10-1) section.
+If any of them reads **Running**, you must stop if first by executing `wsl -t <distro-name>` after replacing `<distro-name>` with the name of the distro you want to stop.
+Once you have stopped all distros, you can continue to the [installation](#install-almalinux-10-1) section.
 
-## Install AlmaLinux10
+## Install AlmaLinux 10
 
 List the available Linux distros by executing:
 
@@ -82,7 +82,7 @@ A distribution with the supplied name already exists. Use --name to choose a dif
 Error code: Wsl/InstallDistro/Service/RegisterDistro/ERROR_ALREADY_EXISTS
 ```
 
-Install the AlmaLinux10 distro by executing the below command:
+Install the **AlmaLinux 10** distro by executing the below command:
 
 ```shell
 wsl --install -d AlmaLinux-10
@@ -101,7 +101,7 @@ Enter new UNIX username:
 ```
 
 As per the last line, the installation process now prompts you to enter a username.
-This is the username you will use inside AlmaLinux10, and it can be any alphanumeric string (for example `dotkernel`):
+This is the username you will use inside **AlmaLinux 10**, and it can be any alphanumeric string (for example `dotkernel`):
 
 Next, you are prompted to change the password associated with your chosen username (you will not see what you are typing, that's a security measure in Linux regarding passwords):
 
@@ -122,10 +122,10 @@ Finally, you should see the following message:
 
 ```text
 passwd: all authentication tokens updated successfully.
-[<your-almalinux10-username>@<your-device-name> <your-windows-username>]$
+[<your-alma-linux-10-username>@<your-device-name> <your-windows-username>]$
 ```
 
-## Setup AlmaLinux10
+## Setup AlmaLinux 10
 
 Install system packages:
 
@@ -147,7 +147,7 @@ For security reasons, the password you type will not be visible.
 [sudo] password for dotkernel:
 ```
 
-Input your AlmaLinux10 password and hit `Enter`.
+Input your **AlmaLinux 10** password and hit `Enter`.
 
 Update/Upgrade system packages:
 
@@ -165,7 +165,7 @@ sudo dnf install ansible-core -y
 ansible-galaxy collection install community.general community.mysql
 ```
 
-Move inside your home directory (it is `/home/` followed by your AlmaLinux10 username, for example: `/home/dotkernel`):
+Move inside your home directory (it is `/home/` followed by your **AlmaLinux 10** username, for example: `/home/dotkernel`):
 
 ```shell
 cd ~
@@ -198,7 +198,7 @@ Install components by running the below Ansible command:
 ansible-playbook -i hosts install.yml --ask-become-pass
 ```
 
-The installation process will ask for your AlmaLinux10 password, then iterate over each task in the playbook and output a short summary with the results.
+The installation process will ask for your **AlmaLinux 10** password, then iterate over each task in the playbook and output a short summary with the results.
 
 Once finished, check if everything works by opening in your browser:
 
@@ -206,9 +206,9 @@ Once finished, check if everything works by opening in your browser:
 * [http://localhost/info.php](http://localhost/info.php): PHP info page
 * [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/): PhpMyAdmin (login with `root` + the root password you configured in `config.yml` under `mariadb` -> `root_password`)
 
-The installation is complete, your AlmaLinux10 development environment is ready to use.
+The installation is complete, your **AlmaLinux 10** development environment is ready to use.
 
-> Restart your `Windows Terminal` to find a new option in the tab selector, called **AlmaLinux-10**; clicking it will open a new tab connected to **AlmaLinux10**.
+> Restart your `Windows Terminal` to find a new option in the tab selector, called **AlmaLinux-10**; clicking it will open a new tab connected to **AlmaLinux 10**.
 
 ## Create virtualhosts
 
@@ -232,7 +232,7 @@ Create the specified virtualhosts:
 ansible-playbook -i hosts create-virtualhost.yml --ask-become-pass
 ```
 
-This process will ask for your AlmaLinux10 password, iterate over the list of configured `virtualhosts` and output a short summary with the results.
+This process will ask for your **AlmaLinux 10** password, iterate over the list of configured `virtualhosts` and output a short summary with the results.
 Your virtualhost should be accessible and ready to use.
 
 You will install your project under the `html` directory of your project, for example `/var/www/example.localhost/html`.
@@ -243,7 +243,7 @@ You will install your project under the `html` directory of your project, for ex
 
 ### Good to know
 
-* To run your installed projects, you need to start AlmaLinux10 first.
+* To run your installed projects, you need to start **AlmaLinux 10** first.
 * If you work with virtualhosts, your projects are created under `/var/www/`.
 * You can still run PHP scripts under the default Apache project directory, located at `/var/www/html/`.
 * If you encounter write permission issues, see [this guide](https://docs.dotkernel.org/development/v2/faq/#how-do-i-fix-common-permission-issues).

--- a/wsl/README.md
+++ b/wsl/README.md
@@ -1,4 +1,4 @@
-# Install AlmaLinux 10
+# AlmaLinux 10 Installation
 
 Before proceeding with the installation, we need to make sure that no other WSL2 distribution (aka: _distro_) is running.
 This is important because this installation will fail if required ports are already in use by another distro.
@@ -19,7 +19,7 @@ If there is no other distro installed, you will see the below output (an empty l
   NAME            STATE           VERSION
 ```
 
-In this case, you can jump to the [installation](#install-almalinux-10-1) section.
+In this case, you can jump to the [installation](#install-almalinux-10) section.
 
 If you have other distros installed, the output could look similar to the below:
 
@@ -31,7 +31,7 @@ If you have other distros installed, the output could look similar to the below:
 
 Make sure that the **STATE** column reads **Stopped** for all distros.
 If any of them reads **Running**, you must stop if first by executing `wsl -t <distro-name>` after replacing `<distro-name>` with the name of the distro you want to stop.
-Once you have stopped all distros, you can continue to the [installation](#install-almalinux-10-1) section.
+Once you have stopped all distros, you can continue to the [installation](#install-almalinux-10) section.
 
 ## Install AlmaLinux 10
 

--- a/wsl/create-virtualhost.yml
+++ b/wsl/create-virtualhost.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create new virtualhost under AlmaLinux10
+- name: Create new virtualhost under AlmaLinux 10
   hosts: localhost
   connection: local
   become: true

--- a/wsl/install.yml
+++ b/wsl/install.yml
@@ -1,5 +1,5 @@
 ---
-- name: Setup AlmaLinux10 development environment
+- name: Setup AlmaLinux 10 development environment
   hosts: localhost
   connection: local
   become: true

--- a/wsl/roles/mariadb/tasks/main.yml
+++ b/wsl/roles/mariadb/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install MariaDB 11.4
+- name: Install the latest version of MariaDB
   command: "dnf install python3-mysqlclient mariadb-server -y"
 - name: Enable and start MariaDB service
   command: systemctl enable --now mariadb


### PR DESCRIPTION
- added _AlmaLinux 10_ text to page headers
- replaced version info with the word "latest" in MariaDB task
- replaced occurrences of `AlmaLinux9`/`AlmaLinux10` with their brand correct references (`AlmaLinux 9`/`AlmaLinux 10`)